### PR TITLE
fix: test service encode watch

### DIFF
--- a/internal/discoverer/discoverer.go
+++ b/internal/discoverer/discoverer.go
@@ -1,6 +1,7 @@
 package discoverer
 
 import (
+	"sort"
 	"strconv"
 
 	"github.com/api7/apisix-seed/internal/core/comm"
@@ -49,6 +50,10 @@ func (s *Service) EncodeEntities() utils.Message {
 	for entity := range s.entities {
 		msg.Add("entity", entity)
 	}
+	sort.Slice(msg, func(i, j int) bool {
+		return msg[i].Value < msg[j].Value
+	})
+
 	return msg
 }
 

--- a/internal/discoverer/discoverer_test.go
+++ b/internal/discoverer/discoverer_test.go
@@ -10,7 +10,7 @@ func TestServiceEncodeWatch(t *testing.T) {
 	tests := []struct {
 		caseDesc    string
 		giveService Service
-		wantMsg     string
+		wantMsg     []string
 	}{
 		{
 			caseDesc: "Test Watch Decode",
@@ -26,20 +26,33 @@ func TestServiceEncodeWatch(t *testing.T) {
 				},
 				args: nil,
 			},
-			wantMsg: `key: event, value: update
+			wantMsg: []string{`key: event, value: update
 key: service, value: test
 key: entity, value: upstream;1
 key: entity, value: upstream;2
 key: node, value: 127.0.0.1:80
 key: weight, value: 10
 key: node, value: 127.0.0.1:8080
-key: weight, value: 20`,
-		},
+key: weight, value: 20`, `key: event, value: update
+key: service, value: test
+key: entity, value: upstream;2
+key: entity, value: upstream;1
+key: node, value: 127.0.0.1:80
+key: weight, value: 10
+key: node, value: 127.0.0.1:8080
+key: weight, value: 20`}},
 	}
 
 	for _, tc := range tests {
 		watch, err := tc.giveService.EncodeWatch()
 		assert.Nil(t, err)
-		assert.True(t, watch.String() == tc.wantMsg, tc.caseDesc)
+		ret := false
+		for _, msg := range tc.wantMsg {
+			if watch.String() == msg {
+				ret = true
+				break
+			}
+		}
+		assert.True(t, ret, tc.caseDesc)
 	}
 }

--- a/internal/discoverer/discoverer_test.go
+++ b/internal/discoverer/discoverer_test.go
@@ -10,7 +10,7 @@ func TestServiceEncodeWatch(t *testing.T) {
 	tests := []struct {
 		caseDesc    string
 		giveService Service
-		wantMsg     []string
+		wantMsg     string
 	}{
 		{
 			caseDesc: "Test Watch Decode",
@@ -21,38 +21,24 @@ func TestServiceEncodeWatch(t *testing.T) {
 					{host: "127.0.0.1:8080", weight: 20},
 				},
 				entities: map[string]struct{}{
-					"upstream;1": {},
 					"upstream;2": {},
+					"upstream;1": {},
 				},
 				args: nil,
 			},
-			wantMsg: []string{`key: event, value: update
+			wantMsg: `key: event, value: update
 key: service, value: test
 key: entity, value: upstream;1
 key: entity, value: upstream;2
 key: node, value: 127.0.0.1:80
 key: weight, value: 10
 key: node, value: 127.0.0.1:8080
-key: weight, value: 20`, `key: event, value: update
-key: service, value: test
-key: entity, value: upstream;2
-key: entity, value: upstream;1
-key: node, value: 127.0.0.1:80
-key: weight, value: 10
-key: node, value: 127.0.0.1:8080
-key: weight, value: 20`}},
+key: weight, value: 20`},
 	}
 
 	for _, tc := range tests {
 		watch, err := tc.giveService.EncodeWatch()
 		assert.Nil(t, err)
-		ret := false
-		for _, msg := range tc.wantMsg {
-			if watch.String() == msg {
-				ret = true
-				break
-			}
-		}
-		assert.True(t, ret, tc.caseDesc)
+		assert.True(t, watch.String() == tc.wantMsg, tc.caseDesc)
 	}
 }


### PR DESCRIPTION
The unit test fails because of the randomness of the map access.