### PR TITLE
docs: fix error in json schema

### DIFF
--- a/docs/en/latest/zookeeper.md
+++ b/docs/en/latest/zookeeper.md
@@ -98,7 +98,7 @@ docker exec -it ${CONTAINERID} /bin/bash
 # Login Zookeeper Client
 root@ae2f093337c1:/apache-zookeeper-3.7.0-bin# ./bin/zkCli.sh
 # Register Service
-[zk: localhost:2181(CONNECTED) 0] create /zookeeper/APISIX-ZK '{"host":"127.0.0.1:1980","weight":100}'
+[zk: localhost:2181(CONNECTED) 0] create /zookeeper/APISIX-ZK '[{"host":"127.0.0.1","port":1980,"weight":100}]'
 ```
 
 - Successful Response


### PR DESCRIPTION
The Chinese version has the correct JSON schema, but the English one does not. This has been fixed.

ref:
https://github.com/api7/apisix-seed/blob/db849ab1b202e060412d5dcaeebd394ee2316962/docs/zh/latest/zookeeper.md?plain=1#L98

cc: @soulbird 