### PR TITLE
fix serveral issues

### DIFF
--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -1,0 +1,31 @@
+FROM golang:alpine AS build
+
+WORKDIR /build
+
+ENV GO111MODULE=on \
+    CGO_ENABLED=0 \
+    GOOS=linux
+
+COPY . .
+
+RUN go version
+
+RUN mkdir -p /usr/local/apisix-seed/logs
+
+RUN go build -o apisix-seed main.go
+
+FROM scratch
+
+WORKDIR /usr/local/apisix-seed
+
+COPY --from=build /usr/local/apisix-seed/logs /usr/local/apisix-seed/logs
+
+COPY --from=build /build/apisix-seed .
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /build/conf/conf.yaml conf/conf.yaml
+
+ENV PATH=$PATH:/usr/local/apisix-seed
+
+ENV APISIX_SEED_WORKDIR /usr/local/apisix-seed
+
+CMD [ "/usr/local/apisix-seed/apisix-seed" ]

--- a/conf/conf.yaml
+++ b/conf/conf.yaml
@@ -13,7 +13,7 @@ etcd:
     # the default value is true, e.g. the certificate will be verified strictly.
 log:
   level: warn
-  path: apisix-seed.log           # path is the file to write logs to.  Backup log files will be retained in the same directory
+  path: logs/apisix-seed.log           # path is the file to write logs to.  Backup log files will be retained in the same directory
   maxage: 168h                    # maxage is the maximum number of days to retain old log files based on the timestamp encoded in their filename
   maxsize: 104857600              # maxsize is the maximum size in megabytes of the log file before it gets rotated. It defaults to 100mb
   rotation_time: 1h               # rotation_time is the log rotation time
@@ -30,9 +30,3 @@ discovery:                       # service discovery center
       connect: 2000              # default 2000ms
       send: 2000                 # default 2000ms
       read: 5000                 # default 5000ms
-  zookeeper:
-    hosts:
-      - "127.0.0.1:2181"
-    prefix: /zookeeper
-    weight: 100                  # default weight for node
-    timeout: 10                  # default 10s

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -1,0 +1,25 @@
+version: "3"
+
+services:
+  apisix_seed_dev:
+    image: hugozhu/apisix-seed
+    build:
+      context: .
+      dockerfile: Dockerfile.minimal
+    restart: always
+    volumes:
+      - ./conf/conf.yaml:/usr/local/apisix-seed/conf/conf.yaml:ro
+      - ./logs:/usr/local/apisix-seed/logs
+    networks:
+      apisix-seed:
+        ipv4_address: 172.50.238.50
+
+networks:
+  apisix-seed:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.50.238.0/24
+          gateway: 172.50.238.1
+

--- a/internal/core/message/a6conf.go
+++ b/internal/core/message/a6conf.go
@@ -6,6 +6,11 @@ import (
 	"strings"
 )
 
+type Labels struct {
+	ServiceName   string `json:"service_name,omitempty"`
+	DiscoveryType string `json:"discovery_type,omitempty"`
+}
+
 type UpstreamArg struct {
 	NamespaceID string                 `json:"namespace_id,omitempty"`
 	GroupName   string                 `json:"group_name,omitempty"`
@@ -103,7 +108,7 @@ func embedElm(v reflect.Value, all map[string]interface{}) {
 		}
 
 		if fieldName == "DiscoveryType" || fieldName == "ServiceName" {
-			all["_"+tagName] = val.Interface()
+			// all["_"+tagName] = val.Interface()
 			delete(all, tagName)
 			continue
 		}
@@ -175,6 +180,7 @@ func NewUpstreams(value []byte) (A6Conf, error) {
 }
 
 type Routes struct {
+	Labels       Labels                 `json:"labels"`
 	Upstream     Upstream               `json:"upstream"`
 	All          map[string]interface{} `json:"-"`
 	hasNodesAttr bool
@@ -206,10 +212,20 @@ func NewRoutes(value []byte) (A6Conf, error) {
 	routes := &Routes{
 		All: make(map[string]interface{}),
 	}
+
+	// println("===", string(value))
+
 	err := unmarshal(value, routes)
 	if err != nil {
 		return nil, err
 	}
+
+	routes.Upstream.ServiceName = routes.Labels.ServiceName
+	routes.Upstream.DiscoveryType = routes.Labels.DiscoveryType
+
+	// if routes.Upstream.ServiceName != "" {
+	// 	println(routes.Upstream.ServiceName)
+	// }
 
 	if routes.Upstream.Nodes != nil {
 		routes.hasNodesAttr = true

--- a/internal/core/message/a6conf.go
+++ b/internal/core/message/a6conf.go
@@ -107,11 +107,14 @@ func embedElm(v reflect.Value, all map[string]interface{}) {
 			continue
 		}
 
-		// if fieldName == "DiscoveryType" || fieldName == "ServiceName" {
-		// 	all["_"+tagName] = val.Interface()
-		// 	delete(all, tagName)
-		// 	continue
-		// }
+		if fieldName == "DiscoveryType" || fieldName == "ServiceName" {
+			typStr := typ.String()
+			if typStr == "message.Upstream" {
+				// all["_"+tagName] = val.Interface()
+				delete(all, tagName)
+				continue
+			}
+		}
 
 		if val.Kind() == reflect.Ptr {
 			val = val.Elem()
@@ -196,11 +199,14 @@ func (routes *Routes) GetAll() *map[string]interface{} {
 }
 
 func (routes *Routes) Marshal() ([]byte, error) {
+	bytes1, _ := json.Marshal(routes.All)
+	print("a6conf marshal 1=====", string(bytes1))
+
 	embedElm(reflect.ValueOf(routes), routes.All)
 
 	// routes.All["labels"] = routes.Labels
 	bytes, error := json.Marshal(routes.All)
-	// print("a6conf marshal 2=====", string(bytes))
+	print("a6conf marshal 2=====", string(bytes))
 	return bytes, error
 }
 
@@ -236,7 +242,7 @@ func NewRoutes(value []byte) (A6Conf, error) {
 		// 	}
 		// }
 		if routes.Labels.ServiceName != "" {
-			print("====", id, "====>", routes.Labels.ServiceName)
+			println("====", id, "====> ", routes.Labels.ServiceName)
 		}
 	}
 

--- a/internal/core/message/a6conf.go
+++ b/internal/core/message/a6conf.go
@@ -226,10 +226,16 @@ func (routes *Routes) Marshal() ([]byte, error) {
 			return nil, fmt.Errorf("invalid grpc port configuration: failed to parse port %s to integer for route %s: %s", routes.Labels.ServiceGrpcPort, routes.All["id"], err)
 		}
 		if nodes, ok := routes.Upstream.Nodes.([]*Node); ok {
-			for _, node := range nodes {
-				node.Port = int(grpcPort)
-				log.Infof("updated gRPC port to %d for node %s in route %s", grpcPort, node.Host, routes.All["id"])
+			nodesCopy := make([]*Node, len(nodes))
+			for i, n := range nodes {
+				nodesCopy[i] = &Node{
+					Host:   n.Host,
+					Weight: n.Weight,
+					Port:   int(grpcPort),
+				}
+				log.Infof("updated gRPC port to %d for node %s in route %s", grpcPort, n.Host, routes.All["id"])
 			}
+			routes.Upstream.Nodes = nodesCopy
 		}
 	}
 

--- a/internal/core/message/a6conf.go
+++ b/internal/core/message/a6conf.go
@@ -6,6 +6,15 @@ import (
 	"strings"
 )
 
+// Sample route config
+// "labels":
+// {
+// 	"discovery_args.group_name": "group_name",
+// 	"discovery_args.namespace_id": "test_name",
+// 	"discovery_type": "nacos",
+// 	"service_name": "test-service"
+// },
+
 type Labels struct {
 	DiscoveryType            string `json:"discovery_type,omitempty"`
 	ServiceName              string `json:"service_name,omitempty"`

--- a/internal/core/message/a6conf.go
+++ b/internal/core/message/a6conf.go
@@ -20,6 +20,7 @@ type Labels struct {
 	ServiceName              string `json:"service_name,omitempty"`
 	DiscoveryArgsNamespaceID string `json:"discovery_args.namespace_id,omitempty"`
 	DiscoveryArgsGroupName   string `json:"discovery_args.group_name,omitempty"`
+	ServiceGrpcPort          string `json:"service_grpc_port,omitempty"`
 }
 
 type UpstreamArg struct {

--- a/internal/core/message/a6conf.go
+++ b/internal/core/message/a6conf.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 )
@@ -86,7 +87,10 @@ func embedElm(v reflect.Value, all map[string]interface{}) {
 		v = v.Elem()
 	}
 
+	println(fmt.Printf("===========Identity of v: %v %v\n", v.Type(), v.Type().Name()))
+
 	typ := v.Type()
+
 	fieldNum := typ.NumField()
 	for i := 0; i < fieldNum; i++ {
 		field := typ.Field(i)

--- a/internal/core/message/a6conf_test.go
+++ b/internal/core/message/a6conf_test.go
@@ -124,11 +124,6 @@ func TestMarshal_Routes(t *testing.T) {
         "pass_host": "pass",
         "type": "roundrobin",
         "hash_on": "vars",
-        "_discovery_type": "nacos",
-        "_service_name": "APISIX-NACOS",
-        "discovery_args": {
-            "group_name": "DEFAULT_GROUP"
-        },
         "nodes": [
             {
                 "host": "192.168.1.1",
@@ -151,6 +146,78 @@ func TestMarshal_Routes(t *testing.T) {
 	assert.Nil(t, err, caseDesc)
 
 	a6.Inject(&nodes)
+	ss, err := a6.Marshal()
+	assert.Nil(t, err, caseDesc)
+
+	assert.JSONEq(t, wantA6Str, string(ss))
+}
+
+func TestMarshal_Routes_With_Grpc_Port(t *testing.T) {
+	givenA6Str := `{
+    "status": 1,
+    "id": "3",
+    "uri": "/hh",
+	 "labels": {
+        "discovery_type": "nacos",
+        "discovery_args.group_name": "DEFAULT_GROUP",
+        "service_name": "test-service",
+		"service_grpc_port":"10001"
+    },
+    "upstream": {
+        "scheme": "http",
+        "pass_host": "pass",
+        "type": "roundrobin",
+        "hash_on": "vars",
+        "nodes": {
+            "192.168.1.1:10001": 1
+        }
+    },
+    "create_time": 1648871506,
+    "priority": 0,
+    "update_time": 1648871506
+}`
+	nodes := []*Node{
+		{Host: "192.168.1.1", Port: 80, Weight: 1},
+		{Host: "192.168.1.2", Port: 80, Weight: 1},
+	}
+
+	wantA6Str := `{
+    "status": 1,
+    "id": "3",
+    "uri": "/hh",
+	"labels": {
+        "discovery_type": "nacos",
+        "discovery_args.group_name": "DEFAULT_GROUP",
+        "service_name": "test-service",
+		"service_grpc_port":"10001"
+    },
+    "upstream": {
+        "scheme": "http",
+        "pass_host": "pass",
+        "type": "roundrobin",
+        "hash_on": "vars",
+        "nodes": [
+            {
+                "host": "192.168.1.1",
+                "port": 10001,
+                "weight": 1
+            },
+            {
+                "host": "192.168.1.2",
+                "port": 10001,
+                "weight": 1
+            }
+        ]
+    },
+    "create_time": 1648871506,
+    "priority": 0,
+    "update_time": 1648871506
+}`
+	caseDesc := "sanity"
+	a6, err := NewA6Conf([]byte(givenA6Str), A6RoutesConf)
+	assert.Nil(t, err, caseDesc)
+
+	a6.Inject(nodes)
 	ss, err := a6.Marshal()
 	assert.Nil(t, err, caseDesc)
 

--- a/internal/core/message/message.go
+++ b/internal/core/message/message.go
@@ -2,7 +2,6 @@ package message
 
 import (
 	"reflect"
-	"strconv"
 )
 
 type StoreEvent = int
@@ -60,23 +59,6 @@ func (msg *Message) DiscoveryType() string {
 		return up.DiscoveryType
 	}
 	return up.DupDiscoveryType
-}
-
-func (msg *Message) ServiceGrpcPort() int {
-	all := msg.a6Conf.GetAll()
-	if all == nil {
-		return 0
-	}
-	grpcPort, ok := (*all)["labels"].(map[string]interface{})["service_grpc_port"]
-	if !ok {
-		return 0
-	}
-	grpcPortInt, err := strconv.Atoi(grpcPort.(string))
-	if err != nil {
-		println("failed to convert grpc port %s to integer: %s", grpcPort, err)
-		return 0
-	}
-	return grpcPortInt
 }
 
 func (msg *Message) DiscoveryArgs() map[string]interface{} {

--- a/internal/core/message/message.go
+++ b/internal/core/message/message.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"reflect"
+	"strconv"
 )
 
 type StoreEvent = int
@@ -59,6 +60,23 @@ func (msg *Message) DiscoveryType() string {
 		return up.DiscoveryType
 	}
 	return up.DupDiscoveryType
+}
+
+func (msg *Message) ServiceGrpcPort() int {
+	all := msg.a6Conf.GetAll()
+	if all == nil {
+		return 0
+	}
+	grpcPort, ok := (*all)["labels"].(map[string]interface{})["service_grpc_port"]
+	if !ok {
+		return 0
+	}
+	grpcPortInt, err := strconv.Atoi(grpcPort.(string))
+	if err != nil {
+		println("failed to convert grpc port %s to integer: %s", grpcPort, err)
+		return 0
+	}
+	return grpcPortInt
 }
 
 func (msg *Message) DiscoveryArgs() map[string]interface{} {

--- a/internal/discoverer/nacos.go
+++ b/internal/discoverer/nacos.go
@@ -124,7 +124,7 @@ func (d *NacosDiscoverer) Stop() {
 
 func (d *NacosDiscoverer) Query(msg *message.Message) error {
 	serviceId := serviceID(msg.ServiceName(), msg.DiscoveryArgs())
-	println("Nacos: ", msg.ServiceName(), msg.DiscoveryArgs(), msg.ServiceGrpcPort())
+	println("Nacos: ", msg.ServiceName(), msg.DiscoveryArgs())
 	d.cacheMutex.Lock()
 	defer d.cacheMutex.Unlock()
 
@@ -138,9 +138,6 @@ func (d *NacosDiscoverer) Query(msg *message.Message) error {
 			id:   serviceId,
 			name: msg.ServiceName(),
 			args: msg.DiscoveryArgs(),
-			a6Conf: map[string]*message.Message{
-				serviceId: msg,
-			},
 		}
 		nodes, err := d.fetch(dis)
 		if err != nil {
@@ -261,7 +258,6 @@ func (d *NacosDiscoverer) fetch(service *NacosService) ([]*message.Node, error) 
 
 	// metadata
 	metadata := service.args["metadata"]
-	grpcPort := service.a6Conf[service.id].ServiceGrpcPort()
 	nodes := make([]*message.Node, 0)
 	for _, host := range serviceInfo.Hosts {
 		if metadata != nil {
@@ -280,13 +276,10 @@ func (d *NacosDiscoverer) fetch(service *NacosService) ([]*message.Node, error) 
 		if weight == 0 {
 			weight = d.weight
 		}
-		port := int(host.Port)
-		if grpcPort != 0 {
-			port = grpcPort
-		}
+
 		nodes = append(nodes, &message.Node{
 			Host:   host.Ip,
-			Port:   port,
+			Port:   int(host.Port),
 			Weight: weight,
 		})
 	}
@@ -294,7 +287,7 @@ func (d *NacosDiscoverer) fetch(service *NacosService) ([]*message.Node, error) 
 	return nodes, nil
 }
 
-func (d *NacosDiscoverer) newSubscribeCallback(serviceId string, metadata interface{}, grpcPort int) func([]model.SubscribeService, error) {
+func (d *NacosDiscoverer) newSubscribeCallback(serviceId string, metadata interface{}) func([]model.SubscribeService, error) {
 	return func(services []model.SubscribeService, err error) {
 		nodes := make([]*message.Node, 0)
 		meta, ok := metadata.(map[string]interface{})
@@ -317,14 +310,9 @@ func (d *NacosDiscoverer) newSubscribeCallback(serviceId string, metadata interf
 				weight = d.weight
 			}
 
-			port := int(inst.Port)
-			if grpcPort != 0 {
-				port = grpcPort
-			}
-
 			nodes = append(nodes, &message.Node{
 				Host:   inst.Ip,
-				Port:   port,
+				Port:   int(inst.Port),
 				Weight: weight,
 			})
 		}
@@ -351,11 +339,10 @@ func (d *NacosDiscoverer) subscribe(service *NacosService, client naming_client.
 	groupName, _ := service.args["group_name"].(string)
 	log.Infof("Nacos subscribe service: %s, groupName: %s", service.name, groupName)
 
-	grpcPort := service.a6Conf[service.id].ServiceGrpcPort()
 	param := &vo.SubscribeParam{
 		ServiceName:       service.name,
 		GroupName:         groupName,
-		SubscribeCallback: d.newSubscribeCallback(service.id, service.args["metadata"], grpcPort),
+		SubscribeCallback: d.newSubscribeCallback(service.id, service.args["metadata"]),
 	}
 
 	// TODO: retry if failed to Subscribe

--- a/main.go
+++ b/main.go
@@ -46,8 +46,10 @@ func initLogger(logConf *conf.Log) error {
 	return nil
 }
 
+var VERSION = 1.1
+
 func main() {
-	println("=========== starting ============")
+	println("=========== version ", VERSION, " ============")
 
 	conf.InitConf()
 

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func initLogger(logConf *conf.Log) error {
 }
 
 func main() {
-	println("===========starting 123============")
+	println("=========== starting ============")
 
 	conf.InitConf()
 

--- a/main.go
+++ b/main.go
@@ -47,6 +47,8 @@ func initLogger(logConf *conf.Log) error {
 }
 
 func main() {
+	println("===========starting 123============")
+
 	conf.InitConf()
 
 	if err := initLogger(conf.LogConfig); err != nil {


### PR DESCRIPTION
issue 1:
when apisix-seed restart empty hosts might be returned, apisix may return 5xx during that peroid.

issue 2:
use 'labels' to tag route with nacos service discovery. 
_discovery_type and _service_name is not compatible in 'upstream'